### PR TITLE
Add Redirect to June Newsletter and Update Other Months

### DIFF
--- a/src/app/newsletter/august/page.tsx
+++ b/src/app/newsletter/august/page.tsx
@@ -1,0 +1,14 @@
+import { notFound, redirect } from 'next/navigation'
+
+export default function August() {
+  const newsletterUrl = "";
+  // after putting the drive link you have comment-out the below redirect code
+  // then remove the notfound page from return and comment-out "<div></div>"
+  
+  // redirect(newsletterUrl);
+
+  return (
+    // <div></div>
+    notFound()
+  );
+}

--- a/src/app/newsletter/july/page.tsx
+++ b/src/app/newsletter/july/page.tsx
@@ -1,0 +1,14 @@
+import { notFound, redirect } from 'next/navigation'
+
+export default function July() {
+  const newsletterUrl = "";
+  // after putting the drive link you have comment-out the below redirect code
+  // then remove the notfound page from return and comment-out "<div></div>"
+  
+  // redirect(newsletterUrl);
+
+  return (
+    // <div></div>
+    notFound()
+  );
+}

--- a/src/app/newsletter/june/page.tsx
+++ b/src/app/newsletter/june/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from 'next/navigation'
+
+export default function June() {
+  const newsletterUrl = "https://drive.google.com/file/d/1svxuAckkjO_7ZuMVEP-H3HKZH89mP4vL/view";
+  redirect(newsletterUrl);
+
+  return (
+    <div></div>
+  );
+}

--- a/src/app/newsletter/september/page.tsx
+++ b/src/app/newsletter/september/page.tsx
@@ -1,0 +1,14 @@
+import { notFound, redirect } from 'next/navigation'
+
+export default function September() {
+  const newsletterUrl = "";
+  // after putting the drive link you have comment-out the below redirect code
+  // then remove the notfound page from return and comment-out "<div></div>"
+  
+  // redirect(newsletterUrl);
+
+  return (
+    // <div></div>
+    notFound()
+  );
+}


### PR DESCRIPTION
## Changes Made

I have added a redirect to the June newsletter and updated the **August, July, and September** newsletter pages with consistent redirect handling. 

- **June**: Added a redirect to the Google Drive link for the June newsletter.
- **August, July, September**: Updated to include a placeholder for a Drive link, with commented-out redirect code and instructions for future updates.